### PR TITLE
fix: redirect to /login when isAuthenticated fails

### DIFF
--- a/src/lib/get-server-side-props/authentication.ts
+++ b/src/lib/get-server-side-props/authentication.ts
@@ -13,7 +13,7 @@ export async function isAuthenticated(context: GetServerSidePropsContext<ParsedU
         return {
             redirect: {
                 permanent: false,
-                destination: '/401'
+                destination: '/login'
             }
         };
     }


### PR DESCRIPTION
### Description

This change redirects us to `/login` when `isAuthenticated` fails on the server side