### PR TITLE
fix: vertical centre of current funds icon

### DIFF
--- a/src/components/layouts/dashboard/DashboardInnerHeader.tsx
+++ b/src/components/layouts/dashboard/DashboardInnerHeader.tsx
@@ -10,7 +10,7 @@ export default function DashboardInnerHeader({ currentFunds }: DashboardInnerHea
             <div className="lg:flex lg:items-center lg:justify-between">
                 <div className="m-3 min-w-0 flex-1">
                     <div className="mt-1 flex flex-row sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
-                        <div className="mt-2 flex items-center text-sm text-gray-500">
+                        <div className="flex text-sm text-gray-500 m-auto">
                             <CurrencyDollarIcon className="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" aria-hidden="true" />
                         </div>
                         <div>{`Current Funds: $${currentFunds / 100}`}</div>


### PR DESCRIPTION
### Description
#### Before 
<img width="1580" alt="Screen Shot 2023-03-25 at 2 03 42 pm" src="https://user-images.githubusercontent.com/3042264/227687932-19485367-3969-4e04-9fe6-f82697f3c08b.png">

#### After
<img width="1624" alt="Screen Shot 2023-03-25 at 2 03 31 pm" src="https://user-images.githubusercontent.com/3042264/227687938-604f6aed-f9c2-4dc2-b0a2-902e02c9e072.png">
