### PR TITLE
fix: make wizard steps take full width

### DIFF
--- a/src/components/page/imageWizard/index.tsx
+++ b/src/components/page/imageWizard/index.tsx
@@ -124,7 +124,7 @@ function WizardDesktop({ wizardSteps, currentStep, setCurrentStep, setCurrentSte
                                         <span className="ml-4 text-sm font-medium text-indigo-600">{step.name}</span>
                                     </a>
                                 ) : (
-                                    <a onClick={() => setCurrentStep(stepIdx)} className="group flex items-center">
+                                    <a onClick={() => setCurrentStep(stepIdx)} className="group flex items-center w-full">
                                         <span className="flex items-center px-6 py-4 text-sm font-medium">
                                             <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border-2 border-gray-300 group-hover:border-gray-400">
                                                 <span className="text-gray-500 group-hover:text-gray-900">{step.id}</span>


### PR DESCRIPTION
### Description

What it says on the tin. Previously, the wizard steps didn't take up their entire container. This meant that mousing over the right edges of the step didn't trigger the :hover state and they weren't clickable. 

adding `w-full` makes them take up their full container and fixes the issue. 

![wizard-steps](https://user-images.githubusercontent.com/3042264/227708433-4e282a94-1699-4505-bdf2-592caac755ea.gif)
